### PR TITLE
Downgrade to ubuntu 20

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     steps:
     - name: Checkout repository and submodules

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout repository and submodules
       uses: actions/checkout@v3
     - name: caml system packages install
-      run: sudo add-apt-repository ppa:avsm/ppa ; sudo apt update ; apt install opam ; # sudo apt-get install unzip opam ocaml-dune libdune-ocaml-dev ocaml-doc
+      run: sudo add-apt-repository ppa:avsm/ppa ; sudo apt update ; sudo apt install opam ; # sudo apt-get install unzip opam ocaml-dune libdune-ocaml-dev ocaml-doc
     - name: Caml dependencies
       run: opam init ; opam switch create 4.14.1; eval $(opam env --switch=4.14.1) ; opam -y install lwt_ppx text lambda-term bigstring angstrom-lwt-unix pcre fileutils ANSITerminal
     - name: Build Octant

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout repository and submodules
       uses: actions/checkout@v3
     - name: caml system packages install
-      run: sudo apt-get install unzip opam ocaml-dune libdune-ocaml-dev ocaml-doc
+      run: sudo add-apt-repository ppa:avsm/ppa ; sudo apt update ; apt install opam ; # sudo apt-get install unzip opam ocaml-dune libdune-ocaml-dev ocaml-doc
     - name: Caml dependencies
       run: opam init ; opam switch create 4.14.1; eval $(opam env --switch=4.14.1) ; opam -y install lwt_ppx text lambda-term bigstring angstrom-lwt-unix pcre fileutils ANSITerminal
     - name: Build Octant

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ This project was initially developed inside [TiPX](https://github.com/lebotlan/t
 
 ## Installation
 
-WIP
-
 You should be able to download the latest build from the "linux" branch on this repository.
 
 ## Running the tool


### PR DESCRIPTION
Previous build would not run on my (not super up to date) cluster, this version of CI forces a ubuntu 20 build with older glibc, should run anywhere not really obsolete.

Setting config back to "ubuntu-latest" will update the config when you think it's appropriate to do so.

The whole build now uses opam:ppa and minimal provided ubuntu package instead on relying on any particular version of ubuntu so should work even on older systems and be easy to update to new ocaml versions.